### PR TITLE
Crud tesorero

### DIFF
--- a/app/Filament/Tesorero/Resources/GastoingresoResource.php
+++ b/app/Filament/Tesorero/Resources/GastoingresoResource.php
@@ -17,6 +17,10 @@ class GastoingresoResource extends Resource
 
     protected static ?string $navigationIcon = 'heroicon-o-chart-pie';
 
+    protected static ?string $label = 'Gasto o Ingreso'; // Singular
+    
+    protected static ?string $pluralLabel = 'Gastos e Ingresos'; // Plural
+
     public static function form(Form $form): Form
     {
         return $form

--- a/app/Filament/Tesorero/Resources/GastoingresoResource.php
+++ b/app/Filament/Tesorero/Resources/GastoingresoResource.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace App\Filament\Tesorero\Resources;
+
+use App\Filament\Tesorero\Resources\GastoingresoResource\Pages;
+use App\Models\Gastoingreso;
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Illuminate\Support\Facades\Storage;
+
+class GastoingresoResource extends Resource
+{
+    protected static ?string $model = Gastoingreso::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-chart-pie';
+
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Forms\Components\Select::make('tipo')
+                    ->label('Tipo')
+                    ->options([
+                        'gasto' => 'Gasto',
+                        'ingreso' => 'Ingreso',
+                    ])
+                    ->required(),
+                Forms\Components\TextInput::make('monto')
+                    ->label('Monto')
+                    ->numeric() // Solo números
+                    ->required()
+                    ->placeholder('Ejemplo: 1500.75'),
+                Forms\Components\Textarea::make('detalle')
+                    ->label('Detalle')
+                    ->required()
+                    ->regex('/^[\p{L}\p{N}\s.,]+$/u') // Soporte para caracteres Unicode (tildes, acentos, etc.)
+                    ->placeholder('Ejemplo: Pago de materiales'),
+                Forms\Components\FileUpload::make('comprobante')
+                    ->label('Comprobante')
+                    ->directory('comprobantes'),
+                Forms\Components\DatePicker::make('fecha')
+                    ->label('Fecha')
+                    ->required(),
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\BadgeColumn::make('tipo')
+                    ->label('Tipo')
+                    ->colors(['success' => 'ingreso', 'danger' => 'gasto'])
+                    ->searchable(), // Habilitar búsqueda en esta columna
+                Tables\Columns\TextColumn::make('monto')
+                    ->label('Monto')
+                    ->money('USD')
+                    ->sortable()
+                    ->searchable(), // Habilitar búsqueda en esta columna
+                Tables\Columns\TextColumn::make('detalle')
+                    ->label('Detalle')
+                    ->searchable(), // Habilitar búsqueda en esta columna
+                Tables\Columns\TextColumn::make('fecha')
+                    ->label('Fecha')
+                    ->date()
+                    ->sortable(),
+                Tables\Columns\ImageColumn::make('comprobante')
+                    ->label('Comprobante')
+                    ->size(60) // Tamaño de la miniatura
+                    ->url(fn ($record) => $record->comprobante ? Storage::url($record->comprobante) : null) // Genera URL pública
+                    ->openUrlInNewTab(), // Abrir en una nueva pestaña
+            ])
+            ->filters([
+                //
+            ])
+            ->actions([
+                Tables\Actions\EditAction::make(),
+                Tables\Actions\ViewAction::make(), // Habilita la acción de ver
+            ])
+            ->bulkActions([
+                Tables\Actions\DeleteBulkAction::make(),
+            ])
+            ->headerActions([]) // Elimina el botón de "Create"
+            ->defaultSort('fecha', 'desc'); // Orden predeterminado
+    }
+
+    public static function getRelations(): array
+    {
+        return [
+            //
+        ];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListGastoingresos::route('/'),
+            'create' => Pages\CreateGastoingreso::route('/create'),
+            'edit' => Pages\EditGastoingreso::route('/{record}/edit'),
+            'view' => Pages\ViewGastoingreso::route('/{record}'),
+        ];
+    }
+}

--- a/app/Filament/Tesorero/Resources/GastoingresoResource/Pages/CreateGastoingreso.php
+++ b/app/Filament/Tesorero/Resources/GastoingresoResource/Pages/CreateGastoingreso.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Filament\Tesorero\Resources\GastoingresoResource\Pages;
+
+use App\Filament\Tesorero\Resources\GastoingresoResource;
+use Filament\Actions;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateGastoingreso extends CreateRecord
+{
+    protected static string $resource = GastoingresoResource::class;
+}

--- a/app/Filament/Tesorero/Resources/GastoingresoResource/Pages/EditGastoingreso.php
+++ b/app/Filament/Tesorero/Resources/GastoingresoResource/Pages/EditGastoingreso.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Tesorero\Resources\GastoingresoResource\Pages;
+
+use App\Filament\Tesorero\Resources\GastoingresoResource;
+use Filament\Actions;
+use Filament\Resources\Pages\EditRecord;
+
+class EditGastoingreso extends EditRecord
+{
+    protected static string $resource = GastoingresoResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\DeleteAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Tesorero/Resources/GastoingresoResource/Pages/ListGastoingresos.php
+++ b/app/Filament/Tesorero/Resources/GastoingresoResource/Pages/ListGastoingresos.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Tesorero\Resources\GastoingresoResource\Pages;
+
+use App\Filament\Tesorero\Resources\GastoingresoResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ListRecords;
+
+class ListGastoingresos extends ListRecords
+{
+    protected static string $resource = GastoingresoResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Tesorero/Resources/GastoingresoResource/Pages/ViewGastoingreso.php
+++ b/app/Filament/Tesorero/Resources/GastoingresoResource/Pages/ViewGastoingreso.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Filament\Tesorero\Resources\GastoingresoResource\Pages;
+
+use App\Filament\Tesorero\Resources\GastoingresoResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ViewRecord;
+
+class ViewGastoingreso extends ViewRecord
+{
+    protected static string $resource = GastoingresoResource::class;
+}

--- a/app/Filament/Tesorero/Resources/InscripcionResource.php
+++ b/app/Filament/Tesorero/Resources/InscripcionResource.php
@@ -20,6 +20,10 @@ class InscripcionResource extends Resource
 
     protected static ?string $navigationIcon = 'heroicon-o-user-group';
 
+    protected static ?string $label = 'Inscripción';
+    
+    protected static ?string $pluralLabel = 'Inscripciones';
+
     public static function form(Form $form): Form
     {
         return $form
@@ -28,6 +32,7 @@ class InscripcionResource extends Resource
                     ->label('Usuario')
                     ->relationship('usuario', 'name')
                     ->searchable()
+                    ->preload() // Carga automáticamente los datos
                     ->required()
                     ->createOptionForm([
                         Forms\Components\TextInput::make('name')
@@ -41,16 +46,31 @@ class InscripcionResource extends Resource
                             ->label('Contraseña')
                             ->password()
                             ->required(),
-                    ]), // Permite ingresar manualmente un usuario
+                    ]),
                 Forms\Components\Select::make('juego_id')
                     ->label('Juego')
                     ->relationship('juego', 'nombre')
                     ->searchable()
+                    ->preload() // Carga automáticamente los datos
                     ->required(),
                 Forms\Components\Select::make('equipo_id')
                     ->label('Equipo')
                     ->relationship('equipo', 'nombre')
-                    ->nullable(),
+                    ->searchable()
+                    ->preload() // Carga automáticamente los datos
+                    ->nullable()
+                    ->createOptionForm([
+                        Forms\Components\TextInput::make('nombre')
+                            ->label('Nombre del Equipo')
+                            ->required()
+                            ->placeholder('Ejemplo: Los Ganadores'),
+                        Forms\Components\Select::make('lider_id')
+                            ->label('Líder del Equipo')
+                            ->relationship('lider', 'name')
+                            ->searchable()
+                            ->preload() // Carga automáticamente los datos
+                            ->nullable(),
+                    ]),
                 Forms\Components\TextInput::make('tipo')
                     ->label('Tipo de inscripción')
                     ->required()
@@ -64,6 +84,11 @@ class InscripcionResource extends Resource
                         'rechazado' => 'Rechazado',
                     ])
                     ->required(),
+                Forms\Components\TextInput::make('numero_comprobante')
+                    ->label('Número de Comprobante')
+                    ->numeric() // Solo números
+                    ->required()
+                    ->placeholder('Ejemplo: 123456789'),
                 Forms\Components\FileUpload::make('imagen_comprobante')
                     ->label('Comprobante')
                     ->directory('comprobantes'),
@@ -100,23 +125,27 @@ class InscripcionResource extends Resource
                     ])
                     ->sortable()
                     ->searchable(),
-                    Tables\Columns\ImageColumn::make('imagen_comprobante')
+                Tables\Columns\TextColumn::make('numero_comprobante')
+                    ->label('N° Comprobante')
+                    ->sortable()
+                    ->searchable(),
+                Tables\Columns\ImageColumn::make('imagen_comprobante')
                     ->label('Comprobante')
                     ->size(60) // Tamaño de la miniatura
                     ->url(fn ($record) => $record->imagen_comprobante ? Storage::url($record->imagen_comprobante) : null) // Genera la URL pública
-                    ->openUrlInNewTab(), // Abrir en una nueva pestaña                
+                    ->openUrlInNewTab(),
             ])
             ->filters([
                 //
             ])
             ->actions([
                 Tables\Actions\EditAction::make(),
-                Tables\Actions\ViewAction::make(), // Habilita la acción de ver
+                Tables\Actions\ViewAction::make(),
             ])
             ->bulkActions([
                 Tables\Actions\DeleteBulkAction::make(),
             ]);
-    }    
+    }
 
     public static function getRelations(): array
     {

--- a/app/Filament/Tesorero/Resources/InscripcionResource.php
+++ b/app/Filament/Tesorero/Resources/InscripcionResource.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace App\Filament\Tesorero\Resources;
+
+use App\Filament\Tesorero\Resources\InscripcionResource\Pages;
+use App\Filament\Tesorero\Resources\InscripcionResource\RelationManagers;
+use App\Models\Inscripcion;
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\SoftDeletingScope;
+use Illuminate\Support\Facades\Storage;
+
+class InscripcionResource extends Resource
+{
+    protected static ?string $model = Inscripcion::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-user-group';
+
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Forms\Components\Select::make('usuario_id')
+                    ->label('Usuario')
+                    ->relationship('usuario', 'name')
+                    ->searchable()
+                    ->required()
+                    ->createOptionForm([
+                        Forms\Components\TextInput::make('name')
+                            ->label('Nombre')
+                            ->required(),
+                        Forms\Components\TextInput::make('email')
+                            ->label('Correo Electrónico')
+                            ->email()
+                            ->required(),
+                        Forms\Components\TextInput::make('password')
+                            ->label('Contraseña')
+                            ->password()
+                            ->required(),
+                    ]), // Permite ingresar manualmente un usuario
+                Forms\Components\Select::make('juego_id')
+                    ->label('Juego')
+                    ->relationship('juego', 'nombre')
+                    ->searchable()
+                    ->required(),
+                Forms\Components\Select::make('equipo_id')
+                    ->label('Equipo')
+                    ->relationship('equipo', 'nombre')
+                    ->nullable(),
+                Forms\Components\TextInput::make('tipo')
+                    ->label('Tipo de inscripción')
+                    ->required()
+                    ->regex('/^[a-zA-Z\s]+$/') // Solo letras y espacios
+                    ->placeholder('Ejemplo: Individual o Grupo'),
+                Forms\Components\Select::make('estado_pago')
+                    ->label('Estado del Pago')
+                    ->options([
+                        'pendiente' => 'Pendiente',
+                        'aprobado' => 'Aprobado',
+                        'rechazado' => 'Rechazado',
+                    ])
+                    ->required(),
+                Forms\Components\FileUpload::make('imagen_comprobante')
+                    ->label('Comprobante')
+                    ->directory('comprobantes'),
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('usuario.name')
+                    ->label('Usuario')
+                    ->sortable()
+                    ->searchable(),
+                Tables\Columns\TextColumn::make('juego.nombre')
+                    ->label('Juego')
+                    ->sortable()
+                    ->searchable(),
+                Tables\Columns\TextColumn::make('equipo.nombre')
+                    ->label('Equipo')
+                    ->sortable()
+                    ->searchable()
+                    ->formatStateUsing(fn ($state) => $state ?? 'Sin equipo'),
+                Tables\Columns\TextColumn::make('tipo')
+                    ->label('Tipo de inscripción')
+                    ->sortable()
+                    ->searchable(),
+                Tables\Columns\BadgeColumn::make('estado_pago')
+                    ->label('Estado del pago')
+                    ->colors([
+                        'success' => 'aprobado',
+                        'danger' => 'rechazado',
+                        'warning' => 'pendiente',
+                    ])
+                    ->sortable()
+                    ->searchable(),
+                    Tables\Columns\ImageColumn::make('imagen_comprobante')
+                    ->label('Comprobante')
+                    ->size(60) // Tamaño de la miniatura
+                    ->url(fn ($record) => $record->imagen_comprobante ? Storage::url($record->imagen_comprobante) : null) // Genera la URL pública
+                    ->openUrlInNewTab(), // Abrir en una nueva pestaña                
+            ])
+            ->filters([
+                //
+            ])
+            ->actions([
+                Tables\Actions\EditAction::make(),
+                Tables\Actions\ViewAction::make(), // Habilita la acción de ver
+            ])
+            ->bulkActions([
+                Tables\Actions\DeleteBulkAction::make(),
+            ]);
+    }    
+
+    public static function getRelations(): array
+    {
+        return [
+            //
+        ];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListInscripcions::route('/'),
+            'create' => Pages\CreateInscripcion::route('/create'),
+            'edit' => Pages\EditInscripcion::route('/{record}/edit'),
+            'view' => Pages\ViewInscripcion::route('/{record}'),
+        ];
+    }    
+}

--- a/app/Filament/Tesorero/Resources/InscripcionResource/Pages/CreateInscripcion.php
+++ b/app/Filament/Tesorero/Resources/InscripcionResource/Pages/CreateInscripcion.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Filament\Tesorero\Resources\InscripcionResource\Pages;
+
+use App\Filament\Tesorero\Resources\InscripcionResource;
+use Filament\Actions;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateInscripcion extends CreateRecord
+{
+    protected static string $resource = InscripcionResource::class;
+}

--- a/app/Filament/Tesorero/Resources/InscripcionResource/Pages/EditInscripcion.php
+++ b/app/Filament/Tesorero/Resources/InscripcionResource/Pages/EditInscripcion.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Tesorero\Resources\InscripcionResource\Pages;
+
+use App\Filament\Tesorero\Resources\InscripcionResource;
+use Filament\Actions;
+use Filament\Resources\Pages\EditRecord;
+
+class EditInscripcion extends EditRecord
+{
+    protected static string $resource = InscripcionResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\DeleteAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Tesorero/Resources/InscripcionResource/Pages/ListInscripcions.php
+++ b/app/Filament/Tesorero/Resources/InscripcionResource/Pages/ListInscripcions.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Tesorero\Resources\InscripcionResource\Pages;
+
+use App\Filament\Tesorero\Resources\InscripcionResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ListRecords;
+
+class ListInscripcions extends ListRecords
+{
+    protected static string $resource = InscripcionResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Tesorero/Resources/InscripcionResource/Pages/ViewInscripcion.php
+++ b/app/Filament/Tesorero/Resources/InscripcionResource/Pages/ViewInscripcion.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Filament\Tesorero\Resources\InscripcionResource\Pages;
+
+use App\Filament\Tesorero\Resources\InscripcionResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ViewRecord;
+
+class ViewInscripcion extends ViewRecord
+{
+    protected static string $resource = InscripcionResource::class;
+}

--- a/app/Filament/Tesorero/Resources/PagoResource.php
+++ b/app/Filament/Tesorero/Resources/PagoResource.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace App\Filament\Tesorero\Resources;
+
+use App\Filament\Tesorero\Resources\PagoResource\Pages;
+use App\Models\Pago;
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Illuminate\Support\Facades\Storage;
+
+class PagoResource extends Resource
+{
+    protected static ?string $model = Pago::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-currency-dollar';
+
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Forms\Components\Select::make('participacion_id')
+                    ->label('Inscripción')
+                    ->relationship('inscripcion', 'id')
+                    ->required(),
+                Forms\Components\Select::make('estado')
+                    ->label('Estado')
+                    ->options([
+                        'pendiente' => 'Pendiente',
+                        'aprobado' => 'Aprobado',
+                        'rechazado' => 'Rechazado',
+                    ])
+                    ->required(),
+                Forms\Components\TextInput::make('numero_comprobante')
+                    ->label('Número de Comprobante')
+                    ->numeric() // Solo números
+                    ->required()
+                    ->placeholder('Ejemplo: 123456789'),
+                Forms\Components\FileUpload::make('imagen_comprobante')
+                    ->label('Comprobante')
+                    ->image() // Muestra la vista previa
+                    ->enableOpen() // Permite abrir la imagen al hacer clic
+                    ->visibility('private'), // Configuración privada
+                Forms\Components\DateTimePicker::make('fecha_pago')
+                    ->label('Fecha del Pago')
+                    ->required(),
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('inscripcion.usuario.name')
+                    ->label('Usuario'),
+                Tables\Columns\BadgeColumn::make('estado')
+                    ->label('Estado')
+                    ->colors([
+                        'success' => 'aprobado',
+                        'danger' => 'rechazado',
+                        'warning' => 'pendiente',
+                    ]),
+                Tables\Columns\TextColumn::make('numero_comprobante')
+                    ->label('N° Comprobante')
+                    ->sortable()
+                    ->searchable(),
+                Tables\Columns\TextColumn::make('fecha_pago')
+                    ->label('Fecha del Pago')
+                    ->date(),
+                Tables\Columns\ImageColumn::make('imagen_comprobante')
+                    ->label('Comprobante')
+                    ->size(60) // Tamaño de la miniatura
+                    ->url(fn ($record) => $record->imagen_comprobante ? Storage::url($record->imagen_comprobante) : null) // Genera la URL pública
+                    ->openUrlInNewTab(), // Abrir en una nueva pestaña
+            ])
+            ->filters([
+                //
+            ])
+            ->actions([
+                Tables\Actions\EditAction::make(),
+                Tables\Actions\ViewAction::make(),
+            ])
+            ->headerActions([]) // Deshabilitar todas las acciones de encabezado
+            ->bulkActions([
+                Tables\Actions\DeleteBulkAction::make(),
+            ]);
+    }
+
+    public static function getRelations(): array
+    {
+        return [
+            //
+        ];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListPagos::route('/'),
+            'edit' => Pages\EditPago::route('/{record}/edit'),
+            'view' => Pages\ViewPago::route('/{record}'),
+        ];
+    }
+}

--- a/app/Filament/Tesorero/Resources/PagoResource.php
+++ b/app/Filament/Tesorero/Resources/PagoResource.php
@@ -17,6 +17,10 @@ class PagoResource extends Resource
 
     protected static ?string $navigationIcon = 'heroicon-o-currency-dollar';
 
+    protected static ?string $label = 'Pago';
+    
+    protected static ?string $pluralLabel = 'Pagos';
+
     public static function form(Form $form): Form
     {
         return $form
@@ -103,4 +107,5 @@ class PagoResource extends Resource
             'view' => Pages\ViewPago::route('/{record}'),
         ];
     }
+    
 }

--- a/app/Filament/Tesorero/Resources/PagoResource/Pages/EditPago.php
+++ b/app/Filament/Tesorero/Resources/PagoResource/Pages/EditPago.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Tesorero\Resources\PagoResource\Pages;
+
+use App\Filament\Tesorero\Resources\PagoResource;
+use Filament\Actions;
+use Filament\Resources\Pages\EditRecord;
+
+class EditPago extends EditRecord
+{
+    protected static string $resource = PagoResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\DeleteAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Tesorero/Resources/PagoResource/Pages/ListPagos.php
+++ b/app/Filament/Tesorero/Resources/PagoResource/Pages/ListPagos.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Tesorero\Resources\PagoResource\Pages;
+
+use App\Filament\Tesorero\Resources\PagoResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ListRecords;
+
+class ListPagos extends ListRecords
+{
+    protected static string $resource = PagoResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Tesorero/Resources/PagoResource/Pages/ListPagos.php
+++ b/app/Filament/Tesorero/Resources/PagoResource/Pages/ListPagos.php
@@ -12,8 +12,6 @@ class ListPagos extends ListRecords
 
     protected function getHeaderActions(): array
     {
-        return [
-            Actions\CreateAction::make(),
-        ];
+        return [];
     }
 }

--- a/app/Filament/Tesorero/Resources/PagoResource/Pages/ViewPago.php
+++ b/app/Filament/Tesorero/Resources/PagoResource/Pages/ViewPago.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Filament\Tesorero\Resources\PagoResource\Pages;
+
+use App\Filament\Tesorero\Resources\PagoResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ViewRecord;
+
+class ViewPago extends ViewRecord
+{
+    protected static string $resource = PagoResource::class;
+}

--- a/app/Models/gastoIngreso.php
+++ b/app/Models/gastoIngreso.php
@@ -19,6 +19,8 @@ class gastoIngreso extends Model
         'usuario_id',
     ];
 
+    public $timestamps = false; // Deshabilita las marcas de tiempo
+
     // Relación con el modelo User
     public function usuario()
     {


### PR DESCRIPTION
Este pull request incluye la adición de varios recursos nuevos para el módulo `Tesorero` en el panel de administración de Filament. Los cambios introducen nuevos recursos para la gestión de las entidades `Gastoingreso`, `Inscripcion` y `Pago`, incluyendo sus respectivos formularios, tablas y páginas.

### Nuevos Recursos Añadidos:
#### Gastoingreso Resource:
* Added `GastoingresoResource` with form schema and table columns for managing `Gastoingreso` entries, including fields for type, amount, details, receipt, and date.
* Created pages for listing, creating, editing, and viewing `Gastoingreso` entries. [[1]](diffhunk://#diff-55a2217c659022d5ab0acd953ceea64ec12f3113a3b150cd2c7f422ace0bd246R1-R12) [[2]](diffhunk://#diff-288cd5c7eeaa54e548635186f362456760f989eb37d14c0c59faf9ec8e7f192cR1-R19) [[3]](diffhunk://#diff-eed61dd769bc2e6f6bba4bb4872ef52faaa1561ecf8af127d6aadf6ab31da617R1-R19) [[4]](diffhunk://#diff-82b0ea404d98dd37ca8ff56b91d70075a59cceab4f6fe8089ddb1d379c1e41a4R1-R12)

#### Inscripcion Resource:
* Added `InscripcionResource` with form schema and table columns for managing `Inscripcion` entries, including fields for user, game, team, type, payment status, receipt number, and receipt image.
* Created pages for listing, creating, editing, and viewing `Inscripcion` entries. [[1]](diffhunk://#diff-abb5024d78377e8ce32295dbfb1e11333536dc9d8644b6030fb61e6933bd4b88R1-R12) [[2]](diffhunk://#diff-2d932d71c69b6399c0686d1848421e691673babebe1ca86bcd4e62f6eaafc610R1-R19) [[3]](diffhunk://#diff-6ed9b599ff768e14076b9b1df43d26b0364bdfc7151979c9cbd1a7526bcba099R1-R19) [[4]](diffhunk://#diff-0299f17e2be3d274fbf09d5afc18a3d4875d07913e614c49dce632641d5e6c85R1-R12)

#### Pago Resource:
* Added `PagoResource` with form schema and table columns for managing `Pago` entries, including fields for participation, status, receipt number, receipt image, and payment date.
* Created pages for listing, editing, and viewing `Pago` entries. [[1]](diffhunk://#diff-9397c99100027edc113f5e7ef75c1cf3de31c3edea50aed47514c4a2ab5fccc6R1-R19) [[2]](diffhunk://#diff-de32e8d8aaeeb158ff8ad067f8c6ea570f4fe239cc199f17f3eb532bab203226R1-R17) [[3]](diffhunk://#diff-2d01d3a6080baf7959e285a1f8ad2d910ebf9cfe169e3bdec58372fda2eead54R1-R12)

### Model Changes:
* Disabled timestamps for the `Gastoingreso` model to prevent automatic timestamp management.