### PR TITLE
Crud_Participante inscripciones realizado

### DIFF
--- a/app/Filament/Participante/Resources/InscripcionResource.php
+++ b/app/Filament/Participante/Resources/InscripcionResource.php
@@ -1,0 +1,173 @@
+<?php
+
+namespace App\Filament\Participante\Resources;
+
+use App\Filament\Participante\Resources\InscripcionResource\Pages;
+use App\Filament\Participante\Resources\InscripcionResource\RelationManagers;
+use App\Models\Inscripcion;
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\SoftDeletingScope;
+use Illuminate\Support\Facades\Storage;
+
+class InscripcionResource extends Resource
+{
+    protected static ?string $model = Inscripcion::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-user-group';
+
+
+    protected static ?string $label = 'Inscripción';
+    
+    protected static ?string $pluralLabel = 'Inscripciones';
+
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Forms\Components\Select::make('usuario_id')
+                    ->label('Usuario')
+                    ->relationship('usuario', 'name')
+                    ->searchable()
+                    ->preload() // Carga automáticamente los datos
+
+                    ->required()
+                    ->createOptionForm([
+                        Forms\Components\TextInput::make('name')
+                            ->label('Nombre')
+                            ->required(),
+                        Forms\Components\TextInput::make('email')
+                            ->label('Correo Electrónico')
+                            ->email()
+                            ->required(),
+                        Forms\Components\TextInput::make('password')
+                            ->label('Contraseña')
+                            ->password()
+                            ->required(),
+                    ]), // Permite ingresar manualmente un usuario
+
+                Forms\Components\Select::make('juego_id')
+                    ->label('Juego')
+                    ->relationship('juego', 'nombre')
+                    ->searchable()
+                    ->preload() // Carga automáticamente los datos
+                    ->required(),
+                Forms\Components\Select::make('equipo_id')
+                    ->label('Equipo')
+                    ->relationship('equipo', 'nombre')
+                    ->searchable()
+                    ->preload() // Carga automáticamente los datos
+                    ->nullable()
+                    ->createOptionForm([
+                        Forms\Components\TextInput::make('nombre')
+                            ->label('Nombre del Equipo')
+                            ->required()
+                            ->placeholder('Ejemplo: Los Ganadores'),
+                        Forms\Components\Select::make('lider_id')
+                            ->label('Líder del Equipo')
+                            ->relationship('lider', 'name')
+                            ->searchable()
+                            ->preload() // Carga automáticamente los datos
+                            ->nullable(),
+                    ]),
+              
+                Forms\Components\TextInput::make('tipo')
+                    ->label('Tipo de inscripción')
+                    ->required()
+                    ->regex('/^[a-zA-Z\s]+$/') // Solo letras y espacios
+                    ->placeholder('Ejemplo: Individual o Grupo'),
+                Forms\Components\Select::make('estado_pago')
+                    ->label('Estado del Pago')
+                    ->options([
+                        'pendiente' => 'Pendiente',
+                        'aprobado' => 'Aprobado',
+                        'rechazado' => 'Rechazado',
+                    ])
+                    ->required(),
+                Forms\Components\TextInput::make('numero_comprobante')
+                    ->label('Número de Comprobante')
+                    ->numeric() // Solo números
+                    ->required()
+                    ->placeholder('Ejemplo: 123456789'),
+
+                Forms\Components\FileUpload::make('imagen_comprobante')
+                    ->label('Comprobante')
+                    ->directory('comprobantes'),
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('usuario.name')
+                    ->label('Usuario')
+                    ->sortable()
+                    ->searchable(),
+                Tables\Columns\TextColumn::make('juego.nombre')
+                    ->label('Juego')
+                    ->sortable()
+                    ->searchable(),
+                Tables\Columns\TextColumn::make('equipo.nombre')
+                    ->label('Equipo')
+                    ->sortable()
+                    ->searchable()
+                    ->formatStateUsing(fn ($state) => $state ?? 'Sin equipo'),
+                Tables\Columns\TextColumn::make('tipo')
+                    ->label('Tipo de inscripción')
+                    ->sortable()
+                    ->searchable(),
+                Tables\Columns\BadgeColumn::make('estado_pago')
+                    ->label('Estado del pago')
+                    ->colors([
+                        'success' => 'aprobado',
+                        'danger' => 'rechazado',
+                        'warning' => 'pendiente',
+                    ])
+                    ->sortable()
+                    ->searchable(),
+                Tables\Columns\TextColumn::make('numero_comprobante')
+                    ->label('N° Comprobante')
+                    ->sortable()
+                    ->searchable(),
+                Tables\Columns\ImageColumn::make('imagen_comprobante')
+                    ->label('Comprobante')
+                    ->size(60) // Tamaño de la miniatura
+                    ->url(fn ($record) => $record->imagen_comprobante ? Storage::url($record->imagen_comprobante) : null) // Genera la URL pública
+                    ->openUrlInNewTab(),
+            ])
+            ->filters([
+                //
+            ])
+            ->actions([
+                Tables\Actions\EditAction::make(),
+
+                Tables\Actions\ViewAction::make(),// Habilita la acción de ver
+
+            ])
+            ->bulkActions([
+                Tables\Actions\DeleteBulkAction::make(),
+            ]);
+
+    }
+
+    public static function getRelations(): array
+    {
+        return [
+            //
+        ];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListInscripcions::route('/'),
+            'create' => Pages\CreateInscripcion::route('/create'),
+            'edit' => Pages\EditInscripcion::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Participante/Resources/InscripcionResource/Pages/CreateInscripcion.php
+++ b/app/Filament/Participante/Resources/InscripcionResource/Pages/CreateInscripcion.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Filament\Participante\Resources\InscripcionResource\Pages;
+
+use App\Filament\Participante\Resources\InscripcionResource;
+use Filament\Actions;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateInscripcion extends CreateRecord
+{
+    protected static string $resource = InscripcionResource::class;
+}

--- a/app/Filament/Participante/Resources/InscripcionResource/Pages/EditInscripcion.php
+++ b/app/Filament/Participante/Resources/InscripcionResource/Pages/EditInscripcion.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Participante\Resources\InscripcionResource\Pages;
+
+use App\Filament\Participante\Resources\InscripcionResource;
+use Filament\Actions;
+use Filament\Resources\Pages\EditRecord;
+
+class EditInscripcion extends EditRecord
+{
+    protected static string $resource = InscripcionResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\DeleteAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Participante/Resources/InscripcionResource/Pages/ListInscripcions.php
+++ b/app/Filament/Participante/Resources/InscripcionResource/Pages/ListInscripcions.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Participante\Resources\InscripcionResource\Pages;
+
+use App\Filament\Participante\Resources\InscripcionResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ListRecords;
+
+class ListInscripcions extends ListRecords
+{
+    protected static string $resource = InscripcionResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Participante/Resources/InscripcionResource/Pages/ViewInscripcion.php
+++ b/app/Filament/Participante/Resources/InscripcionResource/Pages/ViewInscripcion.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Filament\Participante\Resources\InscripcionResource\Pages;
+
+use App\Filament\Participante\Resources\InscripcionResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ViewRecord;
+
+class ViewInscripcion extends ViewRecord
+{
+    protected static string $resource = InscripcionResource::class;
+}


### PR DESCRIPTION
This pull request introduces a new resource for managing inscriptions in the Filament application. The changes include the creation of the `InscripcionResource` class and its associated pages for creating, editing, listing, and viewing inscriptions.

### Resource Management:

* [`app/Filament/Participante/Resources/InscripcionResource.php`](diffhunk://#diff-17a8e737d9dee1b437f2161f8564478a10bce77b29b660c1708285067865499dR1-R173): Created the `InscripcionResource` class to define the form and table schema for managing inscriptions, including fields for user, game, team, inscription type, payment status, receipt number, and receipt image.

### Page Creation:

* [`app/Filament/Participante/Resources/InscripcionResource/Pages/CreateInscripcion.php`](diffhunk://#diff-099e9ca7cdf0b62e7d6a04a6bc7833f47904532aa4817f7c6beb24bcf48eede7R1-R12): Added the `CreateInscripcion` class to handle the creation of new inscriptions.
* [`app/Filament/Participante/Resources/InscripcionResource/Pages/EditInscripcion.php`](diffhunk://#diff-53673550a66dffffe2781ba21f1acff93a8f57e594884929527553f2c891809bR1-R19): Added the `EditInscripcion` class to handle the editing of existing inscriptions, including a delete action.
* [`app/Filament/Participante/Resources/InscripcionResource/Pages/ListInscripcions.php`](diffhunk://#diff-97fc3dcd174fdc1cd9d856a1ba261ddf472ddb73c01f2d0fff366a0c19e82627R1-R19): Added the `ListInscripcions` class to display a list of all inscriptions with the ability to create new ones.
* [`app/Filament/Participante/Resources/InscripcionResource/Pages/ViewInscripcion.php`](diffhunk://#diff-e3fb3ea18c011b59351144507ab7f3e324622125e1194263889d0df47aebe791R1-R12): Added the `ViewInscripcion` class to handle viewing the details of a specific inscription.